### PR TITLE
reorganize and restructure the codebase

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,6 +434,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "errno"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -656,7 +662,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap",
+ "indexmap 1.9.3",
  "slab",
  "tokio",
  "tokio-util",
@@ -840,6 +846,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.0",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -978,6 +994,7 @@ version = "0.0.5"
 dependencies = [
  "chrono",
  "cutils",
+ "indexmap 2.0.0",
  "reqwest",
  "serde",
  "serde_json",
@@ -985,6 +1002,7 @@ dependencies = [
  "songbird",
  "tokio",
  "tracing",
+ "uuid 1.4.1",
 ]
 
 [[package]]
@@ -1670,6 +1688,7 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "reqwest",
+ "rustversion",
  "serde",
  "serde-value",
  "serde_json",
@@ -1788,7 +1807,7 @@ dependencies = [
  "tracing-futures",
  "typemap_rev",
  "url",
- "uuid",
+ "uuid 0.8.2",
  "xsalsa20poly1305",
 ]
 
@@ -2268,6 +2287,15 @@ name = "uuid"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "uuid"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
 dependencies = [
  "getrandom",
 ]

--- a/crates/mockingbird/Cargo.toml
+++ b/crates/mockingbird/Cargo.toml
@@ -12,24 +12,23 @@ tracing = { version = "0.1"}
 tokio = {version = "1.0", default-features=false, features = ["time", "rt"]}
 
 
-[dependencies.uuid]
-version = "1.4.1"
-
 ####
 serde = { version = "1.0", optional=true }
 serde_json = { version = "1.0", optional=true }
 reqwest = { version = "0.11", optional = true, features = ["cookies"]}
-uuid = { version = "^1.4.1", optional = true }
-chrono = {version = "^0.4.26", optional = true }
+chrono = { version = "^0.4.26", optional = true }
 cutils = { path = "../cutils", features = ["tokio"], optional=true }
 
+uuid = { version = "^1.4.1", features = ["v4" ]}
+indexmap = { version = "^2.0.0", optional=true }
 
 [features]
-default = ["controller", "deemix", "ytdl"]
+default = ["controller", "deemix", "ytdl", "roundrobin-queue"]
 controller = []
 debug = []
 
-radio = ["dep:uuid"]
+roundrobin-queue = ["dep:indexmap"]
+
 
 check = ["dep:chrono", "dep:reqwest", "dep:serde", "dep:serde_json"]
 ytdl = ["songbird/yt-dlp"]

--- a/crates/mockingbird/Cargo.toml
+++ b/crates/mockingbird/Cargo.toml
@@ -7,21 +7,29 @@ edition = "2021"
 
 [dependencies]
 songbird = { version = "0.3", features = ["builtin-queue"] }
-serenity = { version = "0.11", default-features=false, features = ["standard_framework", "model", "voice", "client", "gateway", "cache"] }
+serenity = { version = "0.11", default-features=false, features = ["standard_framework", "model", "voice", "client", "gateway", "cache", "collector"] }            
 tracing = { version = "0.1"}
 tokio = {version = "1.0", default-features=false, features = ["time", "rt"]}
+
+
+[dependencies.uuid]
+version = "1.4.1"
 
 ####
 serde = { version = "1.0", optional=true }
 serde_json = { version = "1.0", optional=true }
 reqwest = { version = "0.11", optional = true, features = ["cookies"]}
+uuid = { version = "^1.4.1", optional = true }
 chrono = {version = "^0.4.26", optional = true }
 cutils = { path = "../cutils", features = ["tokio"], optional=true }
 
+
 [features]
-default = []
+default = ["controller", "deemix", "ytdl"]
 controller = []
 debug = []
+
+radio = ["dep:uuid"]
 
 check = ["dep:chrono", "dep:reqwest", "dep:serde", "dep:serde_json"]
 ytdl = ["songbird/yt-dlp"]

--- a/crates/mockingbird/src/controller.rs
+++ b/crates/mockingbird/src/controller.rs
@@ -26,390 +26,412 @@ use std::{
     collections::HashMap,
 };
 
-use crate::player::{MetadataType, QueueContext, TrackRecord, EventEnd};
+use crate::{player::{MetadataType, QueueContext, TrackRecord, EventEnd, TrackRequestFetched}, fan::FetchMetadata};
 
-// use crate::routines::{next_track, join_routine, leave_routine, play_routine};
-
-
-// #[group]
-// #[commands(join, leave, queue, now_playing, skip, clear_seeds, seeds)]
-// struct BetterPlayer;
+use crate::routines::{next_cold_track, join_routine, leave_routine, play_routine};
 
 
-// #[command]
-// #[aliases("np", "playing", "now-playing", "playing-now", "nowplaying")]
-// #[only_in(guilds)]
-// async fn now_playing(ctx: &Context, msg: &Message) -> CommandResult {
-//     let guild = msg.guild(&ctx.cache).unwrap();
-//     let guild_id = guild.id;
+#[group]
+#[commands(join, leave, queue, now_playing, skip, clear_seeds, seeds)]
+struct BetterPlayer;
+
+
+#[command]
+#[aliases("np", "playing", "now-playing", "playing-now", "nowplaying")]
+#[only_in(guilds)]
+async fn now_playing(ctx: &Context, msg: &Message) -> CommandResult {
+    let guild = msg.guild(&ctx.cache).unwrap();
+    let guild_id = guild.id;
  
-//     let manager = songbird::get(ctx)
-//         .await
-//         .expect("Songbird Voice client placed in at initialisation.")
-//         .clone();
+    let manager = songbird::get(ctx)
+        .await
+        .expect("Songbird Voice client placed in at initialisation.")
+        .clone();
 
-//     let call_lock = match manager.get(guild_id) {
-//         Some(call) => call,
-//         None => {
-//             msg.channel_id
-//                .say(&ctx.http, "Not in a voice channel to play in")
-//                .await?;
-//             return Ok(())
-//         }
-//     };
+    let call_lock = match manager.get(guild_id) {
+        Some(call) => call,
+        None => {
+            msg.channel_id
+               .say(&ctx.http, "Not in a voice channel to play in")
+               .await?;
+            return Ok(())
+        }
+    };
 
-//     let handle = match call_lock.lock().await.queue().current() {
-//         Some(handle) => handle,
-//         None => {
-//             msg.channel_id
-//                .say(&ctx.http, "Nothing is currently playing")
-//                .await?;
+    let handle = match call_lock.lock().await.queue().current() {
+        Some(handle) => handle,
+        None => {
+            msg.channel_id
+               .say(&ctx.http, "Nothing is currently playing")
+               .await?;
 
-//             return Ok(())
-//         }
-//     };
+            return Ok(())
+        }
+    };
     
-//     let reactions = vec![
-//         ReactionType::from('\u{23ee}'),
-//         ReactionType::from('\u{25c0}'),
-//         ReactionType::from('\u{25b6}')  
-//     ];
-//     let mut glob = ctx.data.write().await; 
-//     let qctx = glob.get_mut::<crate::LazyQueueKey>()
-//         .expect("Expected LazyQueueKey in TypeMap")
-//         .get_mut(&guild_id).unwrap().clone();
+    let reactions = vec![
+        ReactionType::from('\u{23ee}'),
+        ReactionType::from('\u{25c0}'),
+        ReactionType::from('\u{25b6}')  
+    ];
+
+    let mut glob = ctx.data.write().await; 
+    let qctx = glob.get_mut::<crate::LazyQueueKey>()
+        .expect("Expected LazyQueueKey in TypeMap")
+        .get_mut(&guild_id).unwrap().clone();
         
 
-//     let reply = msg.channel_id.send_message(&ctx.http, |b|
-//         b.reactions(reactions.clone())
-//          .content(
-//             format!(
-//                 "{}: {}", qctx.voice_chan_id.mention(),
-//                 handle.metadata()
-//                     .clone()
-//                     .source_url
-//                     .unwrap_or("Unknown".to_string())
-//             )
-//         )).await?;
+    let reply = msg.channel_id.send_message(&ctx.http, |b|
+        b.reactions(reactions.clone())
+         .content(
+            format!(
+                "{}: {}", qctx.voice_chan_id.mention(),
+                handle.metadata()
+                    .clone()
+                    .source_url
+                    .unwrap_or("Unknown".to_string())
+            )
+        )).await?;
 
+    let mut collector = reply
+        .await_reactions(&ctx)
+        .collect_limit(10)
+        .timeout(std::time::Duration::from_secs(30))
+        .filter(move |r| {
+           reactions.contains(&r.emoji)
+        }).build();
+
+    let mut vote : i32 = 0;
+    let mut different_vote : i32= 0;
+
+    while let Some(reaction) = collector.next().await {
+        let reaction = &reaction.as_ref().as_inner_ref();
+        let emoji = &reaction.emoji;
+        match emoji.as_data().as_str() {
+            "\u{23ee}" => vote += 1,
+            "\u{23c0}" => vote -= 1,
+            "\u{23b6}" =>  different_vote += 1,
+            _ => unreachable!()
+        }
+    }
+
+    // positive
+    if 0 < vote && vote > different_vote {
+        // let cold_queue = qctx.cold_queue.write().await;
+        // let first = cold_queue.has_played.front().unwrap();                
+        // cold_queue.seeds.push_front(first.metadata.clone());
+    }
     
-//     let mut collector = reply
-//         .await_reactions(&ctx)
-//         .collect_limit(10)
-//         .timeout(std::time::Duration::from_secs(30))
-//         .filter(move |r| {
-//            reactions.contains(&r.emoji)
-//         }).build();
+    else if different_vote > vote || (0 > vote && different_vote > vote.abs())  {
+        let _ = handle.stop();
+    }
 
-//     let mut vote : i32 = 0;
-//     let mut different_vote : i32= 0;
+    Ok(())
+}
 
-//     while let Some(reaction) = collector.next().await {
-//         let reaction = &reaction.as_ref().as_inner_ref();
-//         let emoji = &reaction.emoji;
-//         match emoji.as_data().as_str() {
-//             "\u{23ee}" => vote += 1,
-//             "\u{23c0}" => vote -= 1,
-//             "\u{23b6}" =>  different_vote += 1,
-//             _ => unreachable!()
-//         }
-//     }
+#[command]
+#[only_in(guilds)]
+async fn join(ctx: &Context, msg: &Message) -> CommandResult {
+    let connect_to = join_routine(&ctx, msg).await;
+    
+    if let Err(ref e) = connect_to {
+        msg.channel_id
+           .say(&ctx.http, format!("Failed to join voice channel: {:?}", e))
+           .await?;
+    };
 
-//     // positive
-//     if 0 < vote && vote > different_vote {
-//         let cold_queue = qctx.cold_queue.write().await;
-//         let first = cold_queue.has_played.front().unwrap();                
-//         cold_queue.seeds.push_front(first.metadata.clone());
+    msg.channel_id
+       .say(&ctx.http, format!("Joined {}", connect_to.unwrap().voice_chan_id.mention()))
+       .await?;
+
+    Ok(())
+}
+
+#[command]
+#[only_in(guilds)]
+async fn leave(ctx: &Context, msg: &Message) -> CommandResult {
+    let guild = msg.guild(&ctx.cache).unwrap();
+    let guild_id = guild.id;
+
+    let manager = songbird::get(ctx)
+        .await
+        .expect("songbird voice client placed in at initialisation.")
+        .clone();
+
+    let handler = manager.get(guild_id);
+    
+    if handler.is_none() {
+        msg.reply(ctx, "Not in a voice channel").await?;
+        return Ok(())
+    }
+    
+    let handler = handler.unwrap();
+
+    {
+        let mut call = handler.lock().await;
+        call.remove_all_global_events();
+        call.stop();
+        let _ = call.deafen(false).await;
+    }
+
+    if let Err(e) = manager.remove(guild_id).await {
+        msg.channel_id
+           .say(&ctx.http, format!("Failed: {:?}", e))
+           .await?;
+    }
+    
+    {
+        let mut glob = ctx.data.write().await; 
+        let queue = glob.get_mut::<crate::LazyQueueKey>().expect("Expected LazyQueueKey in TypeMap");
+        queue.remove(&guild_id);
+    }
+
+    msg.channel_id.say(&ctx.http, "Left voice channel").await?;
+    Ok(())
+}
+
+use crate::fan::{LinkParser};
+
+async fn parse_url<T: LinkParser>(url: &str, parser: T) -> Option<TrackRequestFetched> {    
+    
+    if let Some(x) = parser.parse_url(url) {
+
+    }
+
+    None
+}
+
+#[command]
+#[aliases("play", "p", "q", "add")]
+#[only_in(guilds)]
+async fn queue(ctx: &Context, msg: &Message, mut args: Args) -> CommandResult {
+    let url = match args.single::<String>() {
+        Ok(url) => url,
+        Err(_) => {
+            msg.channel_id
+               .say(&ctx.http, "Must provide a URL to a video or audio")
+               .await
+               .unwrap();
+            return Ok(());
+        },
+    };
+
+    if !url.starts_with("http") {
+        msg.channel_id
+           .say(&ctx.http, "Must provide a valid URL")
+           .await
+           .unwrap();
+        return Ok(());
+    };
+
+    let guild = msg.guild(&ctx.cache).unwrap();
+    let guild_id = guild.id;
+
+    let manager = songbird::get(ctx)
+        .await
+        .expect("Songbird Voice client placed in at initialisation.")
+        .clone();
+
+    let qctx: Arc<QueueContext>;
+
+    let call = match manager.get(guild_id) {
+        Some(call_lock) => {
+            qctx = ctx.data.write().await.get_mut::<crate::LazyQueueKey>()
+                .unwrap()
+                .get_mut(&guild_id)
+                .unwrap()
+                .clone();
+            
+            call_lock
+        },
         
-//     }
+        None => {
+            let tmp = join_routine(ctx, msg).await;            
+
+            if let Err(ref e) = tmp {
+                msg.channel_id
+                   .say(&ctx.http, format!("Failed to join voice channel: {:?}", e))
+                   .await
+                   .unwrap();        
+                return Ok(());
+            };
+            qctx = tmp.unwrap();
+            msg.channel_id
+                   .say(&ctx.http, format!("Joined: {}", qctx.voice_chan_id.mention()))
+                   .await
+                   .unwrap();
+
+            let call = manager.get(guild_id).ok_or_else(|| JoinError::NoCall);
+            call?
+        }
+    };
+
+    let player = Players::from_str(&url)
+        .ok_or_else(|| String::from("Failed to select extractor for URL"))?;
+
+    let mut uris = player.fan_collection(url.as_str()).await?;
     
-//     else if different_vote > vote || (0 > vote && different_vote > vote.abs())  {
-//         let _ = handle.stop();
-//     }
-
-//     Ok(())
-// }
-
-// #[command]
-// #[only_in(guilds)]
-// async fn join(ctx: &Context, msg: &Message) -> CommandResult {
-//     let connect_to = join_routine(&ctx, msg).await;
-    
-//     if let Err(ref e) = connect_to {
-//         msg.channel_id
-//            .say(&ctx.http, format!("Failed to join voice channel: {:?}", e))
-//            .await?;
-//     };
-
-//     msg.channel_id
-//        .say(&ctx.http, format!("Joined {}", connect_to.unwrap().voice_chan_id.mention()))
-//        .await?;
-
-//     Ok(())
-// }
-
-// #[command]
-// #[only_in(guilds)]
-// async fn leave(ctx: &Context, msg: &Message) -> CommandResult {
-//     let guild = msg.guild(&ctx.cache).unwrap();
-//     let guild_id = guild.id;
-
-//     let manager = songbird::get(ctx)
-//         .await
-//         .expect("songbird voice client placed in at initialisation.")
-//         .clone();
-
-//     let handler = manager.get(guild_id);
-    
-//     if handler.is_none() {
-//         msg.reply(ctx, "Not in a voice channel").await?;
-//         return Ok(())
-//     }
-    
-//     let handler = handler.unwrap();
-
-//     {
-//         let mut call = handler.lock().await;
-//         call.remove_all_global_events();
-//         call.stop();
-//         let _ = call.deafen(false).await;
-//     }
-
-//     if let Err(e) = manager.remove(guild_id).await {
-//         msg.channel_id
-//            .say(&ctx.http, format!("Failed: {:?}", e))
-//            .await?;
-//     }
-    
-//     {
-//         let mut glob = ctx.data.write().await; 
-//         let queue = glob.get_mut::<crate::LazyQueueKey>().expect("Expected LazyQueueKey in TypeMap");
-//         queue.remove(&guild_id);
-//     }
-
-//     msg.channel_id.say(&ctx.http, "Left voice channel").await?;
-//     Ok(())
-// }
-
-// #[command]
-// #[aliases("play", "p", "q", "add")]
-// #[only_in(guilds)]
-// async fn queue(ctx: &Context, msg: &Message, mut args: Args) -> CommandResult {
-//     let url = match args.single::<String>() {
-//         Ok(url) => url,
-//         Err(_) => {
-//             msg.channel_id
-//                .say(&ctx.http, "Must provide a URL to a video or audio")
-//                .await
-//                .unwrap();
-//             return Ok(());
-//         },
-//     };
-
-//     if !url.starts_with("http") {
-//         msg.channel_id
-//            .say(&ctx.http, "Must provide a valid URL")
-//            .await
-//            .unwrap();
-//         return Ok(());
-//     };
-
-//     let guild = msg.guild(&ctx.cache).unwrap();
-//     let guild_id = guild.id;
-
-//     let manager = songbird::get(ctx)
-//         .await
-//         .expect("Songbird Voice client placed in at initialisation.")
-//         .clone();
-
-//     let qctx: Arc<QueueContext>;
-
-//     let call = match manager.get(guild_id) {
-//         Some(call_lock) => {
-//             qctx = ctx.data.write().await.get_mut::<LazyQueueKey>().unwrap().get_mut(&guild_id).unwrap().clone();
-//             call_lock
-//         },
-        
-//         None => {
-//             let tmp = join_routine(ctx, msg).await;            
-
-//             if let Err(ref e) = tmp {
-//                 msg.channel_id
-//                    .say(&ctx.http, format!("Failed to join voice channel: {:?}", e))
-//                    .await
-//                    .unwrap();        
-//                 return Ok(());
-//             };
-//             qctx = tmp.unwrap();
-//             msg.channel_id
-//                    .say(&ctx.http, format!("Joined: {}", qctx.voice_chan_id.mention()))
-//                    .await
-//                    .unwrap();
-
-//             let call = manager.get(guild_id).ok_or_else(|| JoinError::NoCall);
-//             call?
-//         }
-//     };
-
-//     match Players::from_str(&url)
-//         .ok_or_else(|| String::from("Failed to select extractor for URL"))
-//     {
-//         Ok(player) => {
-//             let mut uris = player.fan_collection(url.as_str()).await?;
-//             let added = uris.len();
+    match Players::from_str(&url)
+        .ok_or_else(|| String::from("Failed to select extractor for URL"))
+    {
+        Ok(player) => {
+            let added = uris.len();
             
-//             // YTDLP singles don't work.
-//             // so instead, use the original URI.
-//             if uris.len() == 1 && player == Players::Ytdl {
-//                 uris.clear();
-//                 uris.push_back(url.clone());
-//             }
+            // YTDLP singles don't work.
+            // so instead, use the original URI.
+            if uris.len() == 1 && player == Players::Ytdl {
+                uris.clear();
+                uris.push_back(url.clone());
+            }
             
-//             qctx.cold_queue.write().await.queue.extend(uris.drain(..));    
+            qctx.cold_queue.write().await.queue.extend(uris.drain(..));    
 
-//             let maybe_hot = {
-//                 let call = call.lock().await;
-//                 call.queue().len() > 0            
-//             };
+            let maybe_hot = {
+                let call = call.lock().await;
+                call.queue().len() > 0            
+            };
 
-//             drop(call); // probably not needed, but just in case
-//             if !maybe_hot {
-//                 uqueue_routine(qctx.clone()).await?;
-//             }
+            drop(call); // probably not needed, but just in case
+            if !maybe_hot {
+                uqueue_routine(qctx.clone()).await?;
+            }
 
-//             let content = format!(
-//                 "Added {} Song(s) [{}] queued",
-//                 added,
-//                 qctx.cold_queue.read().await.queue.len()
-//             );
+            let content = format!(
+                "Added {} Song(s) [{}] queued",
+                added,
+                qctx.cold_queue.read().await.queue.len()
+            );
             
-//             msg.channel_id            
-//                .say(&ctx.http, &content)
-//                .await?;            
-//         },
+            msg.channel_id            
+               .say(&ctx.http, &content)
+               .await?;            
+        },
 
-//         Err(_) => {
-//             msg.channel_id
-//                .say(&ctx.http, format!("Failed to select extractor for URL: {}", url))
-//                .await?;
-//         }
-//     }
+        Err(_) => {
+            msg.channel_id
+               .say(&ctx.http, format!("Failed to select extractor for URL: {}", url))
+               .await?;
+        }
+    }
 
-//     Ok(())
-// }
+    Ok(())
+}
 
-// #[command]
-// #[only_in(guilds)]
-// async fn clear_seeds(ctx: &Context, msg: &Message, args: Args) -> CommandResult {
-//     let guild = msg.guild(&ctx.cache).unwrap();
-//     let guild_id = guild.id;
+#[command]
+#[only_in(guilds)]
+async fn clear_seeds(ctx: &Context, msg: &Message, args: Args) -> CommandResult {
+    let guild = msg.guild(&ctx.cache).unwrap();
+    let guild_id = guild.id;
 
 
-//     let qctx = ctx.data.write().await
-//         .get_mut::<LazyQueueKey>().unwrap()
-//         .get_mut(&guild_id).unwrap().clone();
+    let qctx = ctx.data.write().await
+        .get_mut::<crate::LazyQueueKey>().unwrap()
+        .get_mut(&guild_id).unwrap().clone();
 
-//     {
-//         let mut cold_queue = qctx.cold_queue.write().await;
-//         cold_queue.seeds.clear();
-//         msg.channel_id.say(&ctx.http, String::from("Cleared.")).await?;
-//     }
-//     Ok(())
-// }
+    {
+        let mut queue = qctx.queue;
+        if let Some(radio) = queue.radio {
+            radio.seeds.clear();
+        }
 
-// #[command]
-// #[only_in(guilds)]
-// async fn seeds(ctx: &Context, msg: &Message, args: Args) -> CommandResult {
-//     let guild = msg.guild(&ctx.cache).unwrap();
-//     let guild_id = guild.id;
+        msg.channel_id.say(&ctx.http, String::from("Cleared.")).await?;
+    }
+    Ok(())
+}
 
-//     let qctx = ctx.data.write().await
-//         .get_mut::<LazyQueueKey>().unwrap()
-//         .get_mut(&guild_id).unwrap().clone();
+#[command]
+#[only_in(guilds)]
+async fn seeds(ctx: &Context, msg: &Message, args: Args) -> CommandResult {
+    let guild = msg.guild(&ctx.cache).unwrap();
+    let guild_id = guild.id;
 
-//     {
-//         let cold_queue = qctx.cold_queue.read().await;
-//         let seeds = &cold_queue.seeds.range(..)
-//             .cloned().collect::<Vec<_>>().join(", ");
-//         msg.channel_id.say(&ctx.http, format!("Seeds: {}", seeds)).await?;
-//     }
-//     Ok(())
-// }
+    let qctx = ctx.data.write().await
+        .get_mut::<crate::LazyQueueKey>().unwrap()
+        .get_mut(&guild_id).unwrap().clone();
 
-// #[command]
-// #[only_in(guilds)]
-// async fn skip(ctx: &Context, msg: &Message, args: Args) -> CommandResult {
-//     let guild = msg.guild(&ctx.cache).unwrap();
-//     let guild_id = guild.id;
+    {
+        let cold_queue = qctx.cold_queue.read().await;
+        let seeds = &cold_queue.seeds.range(..)
+            .cloned().collect::<Vec<_>>().join(", ");
+        msg.channel_id.say(&ctx.http, format!("Seeds: {}", seeds)).await?;
+    }
+    Ok(())
+}
+
+#[command]
+#[only_in(guilds)]
+async fn skip(ctx: &Context, msg: &Message, args: Args) -> CommandResult {
+    let guild = msg.guild(&ctx.cache).unwrap();
+    let guild_id = guild.id;
     
-//     let qctx = ctx.data.write().await
-//         .get_mut::<LazyQueueKey>().unwrap()
-//         .get_mut(&guild_id).unwrap().clone();
+    let qctx = ctx.data.write().await
+        .get_mut::<crate::LazyQueueKey>().unwrap()
+        .get_mut(&guild_id).unwrap().clone();
 
-//     let cold_queue_len = qctx.cold_queue.read().await.queue.len();
+    let cold_queue_len = qctx.queue.cold.len();
      
-//     let skipn = args.remains()
-//         .unwrap_or("1")
-//         .parse::<isize>()
-//         .unwrap_or(1);
+    let skipn = args.remains()
+        .unwrap_or("1")
+        .parse::<isize>()
+        .unwrap_or(1);
 
-//     // stop_event: EventEnd::UnMarked,
+    // stop_event: EventEnd::UnMarked,
 
-//     if 1 > skipn  {
-//         msg.channel_id
-//            .say(&ctx.http, "Must skip at least 1 song")
-//            .await?;
-//         return Ok(())
-//     }
+    if 1 > skipn  {
+        msg.channel_id
+           .say(&ctx.http, "Must skip at least 1 song")
+           .await?;
+        return Ok(())
+    }
 
-//     else if skipn >= cold_queue_len as isize + 1 {
-//         qctx.cold_queue.write().await.queue.clear();
-//     }
+    else if skipn >= cold_queue_len as isize + 1 {
+        qctx.queue.cold.clear();
+    }
 
-//     else {
-//         let mut cold_queue = qctx.cold_queue.write().await;
-//         let bottom = cold_queue.queue.split_off(skipn as usize - 1);
-//         cold_queue.queue.clear();
-//         cold_queue.queue.extend(bottom);
-//     }
+    else {
+        let mut cold_queue = qctx.queue.cold;
+        let bottom = cold_queue.split_off(skipn as usize - 1);
+        cold_queue.queue.clear();
+        cold_queue.queue.extend(bottom);
+    }
     
-//     {
-//         let mut cold_queue = qctx.cold_queue.write().await;
-//         if let Some(x) = cold_queue.has_played.front_mut()
-//         {
-//             if let EventEnd::UnMarked = x.stop_event 
-//             {
-//                 x.stop_event = EventEnd::Skipped;
-//                 x.end = Instant::now();
-//             }
-//         }
-//     }
+    {   
+        let mut queue = qctx.queue;
+        if let Some(x) = queue.has_played.front_mut()
+        {
+            if let EventEnd::UnMarked = x.stop_event 
+            {
+                x.stop_event = EventEnd::Skipped;
+                x.end = Instant::now();
+            }
+        }
+    }
 
-//     let manager = songbird::get(ctx)
-//         .await
-//         .expect("Songbird Voice client placed in at initialisation.")
-//         .clone();
+    let manager = songbird::get(ctx)
+        .await
+        .expect("Songbird Voice client placed in at initialisation.")
+        .clone();
 
-//     match manager.get(guild_id) {
-//         Some(call) => {
-//             let call = call.lock().await;
-//             let queue = call.queue();
-//             let _ = queue.skip();
-//         }
-//         None => {
-//             msg.channel_id
-//                .say(&ctx.http, "Not in a voice channel to play in")
-//                .await?;
-//             return Ok(())
-//         }
-//     };
+    match manager.get(guild_id) {
+        Some(call) => {
+            let call = call.lock().await;
+            let queue = call.queue();
+            let _ = queue.skip();
+        }
+        None => {
+            msg.channel_id
+               .say(&ctx.http, "Not in a voice channel to play in")
+               .await?;
+            return Ok(())
+        }
+    };
 
-//     msg.channel_id
-//        .say(
-//             &ctx.http,
-//             format!("Song skipped [{}]: {} in queue.", skipn, cold_queue_len as isize),
-//        )
-//        .await?;
+    msg.channel_id
+       .say(
+            &ctx.http,
+            format!("Song skipped [{}]: {} in queue.", skipn, cold_queue_len as isize),
+       )
+       .await?;
 
-//     Ok(())
-// }
+    Ok(())
+}

--- a/crates/mockingbird/src/controller.rs
+++ b/crates/mockingbird/src/controller.rs
@@ -1,0 +1,415 @@
+use serenity::{
+    async_trait,
+    model::channel::Message,
+    framework::standard::{
+        macros::{command, group},
+        CommandResult, Args,
+    }, 
+    client::Cache,
+    prelude::*,
+    
+    model::prelude::*, http::Http, json
+};
+
+use serenity::futures::StreamExt;
+
+use songbird::{
+    error::{JoinResult, JoinError},
+   TrackEvent
+};
+
+use std::{
+    process::Stdio,
+    time::{Duration, Instant},
+    collections::{VecDeque, HashSet},
+    sync::Arc,
+    collections::HashMap,
+};
+
+use crate::player::{MetadataType, QueueContext, TrackRecord, EventEnd};
+
+// use crate::routines::{next_track, join_routine, leave_routine, play_routine};
+
+
+// #[group]
+// #[commands(join, leave, queue, now_playing, skip, clear_seeds, seeds)]
+// struct BetterPlayer;
+
+
+// #[command]
+// #[aliases("np", "playing", "now-playing", "playing-now", "nowplaying")]
+// #[only_in(guilds)]
+// async fn now_playing(ctx: &Context, msg: &Message) -> CommandResult {
+//     let guild = msg.guild(&ctx.cache).unwrap();
+//     let guild_id = guild.id;
+ 
+//     let manager = songbird::get(ctx)
+//         .await
+//         .expect("Songbird Voice client placed in at initialisation.")
+//         .clone();
+
+//     let call_lock = match manager.get(guild_id) {
+//         Some(call) => call,
+//         None => {
+//             msg.channel_id
+//                .say(&ctx.http, "Not in a voice channel to play in")
+//                .await?;
+//             return Ok(())
+//         }
+//     };
+
+//     let handle = match call_lock.lock().await.queue().current() {
+//         Some(handle) => handle,
+//         None => {
+//             msg.channel_id
+//                .say(&ctx.http, "Nothing is currently playing")
+//                .await?;
+
+//             return Ok(())
+//         }
+//     };
+    
+//     let reactions = vec![
+//         ReactionType::from('\u{23ee}'),
+//         ReactionType::from('\u{25c0}'),
+//         ReactionType::from('\u{25b6}')  
+//     ];
+//     let mut glob = ctx.data.write().await; 
+//     let qctx = glob.get_mut::<crate::LazyQueueKey>()
+//         .expect("Expected LazyQueueKey in TypeMap")
+//         .get_mut(&guild_id).unwrap().clone();
+        
+
+//     let reply = msg.channel_id.send_message(&ctx.http, |b|
+//         b.reactions(reactions.clone())
+//          .content(
+//             format!(
+//                 "{}: {}", qctx.voice_chan_id.mention(),
+//                 handle.metadata()
+//                     .clone()
+//                     .source_url
+//                     .unwrap_or("Unknown".to_string())
+//             )
+//         )).await?;
+
+    
+//     let mut collector = reply
+//         .await_reactions(&ctx)
+//         .collect_limit(10)
+//         .timeout(std::time::Duration::from_secs(30))
+//         .filter(move |r| {
+//            reactions.contains(&r.emoji)
+//         }).build();
+
+//     let mut vote : i32 = 0;
+//     let mut different_vote : i32= 0;
+
+//     while let Some(reaction) = collector.next().await {
+//         let reaction = &reaction.as_ref().as_inner_ref();
+//         let emoji = &reaction.emoji;
+//         match emoji.as_data().as_str() {
+//             "\u{23ee}" => vote += 1,
+//             "\u{23c0}" => vote -= 1,
+//             "\u{23b6}" =>  different_vote += 1,
+//             _ => unreachable!()
+//         }
+//     }
+
+//     // positive
+//     if 0 < vote && vote > different_vote {
+//         let cold_queue = qctx.cold_queue.write().await;
+//         let first = cold_queue.has_played.front().unwrap();                
+//         cold_queue.seeds.push_front(first.metadata.clone());
+        
+//     }
+    
+//     else if different_vote > vote || (0 > vote && different_vote > vote.abs())  {
+//         let _ = handle.stop();
+//     }
+
+//     Ok(())
+// }
+
+// #[command]
+// #[only_in(guilds)]
+// async fn join(ctx: &Context, msg: &Message) -> CommandResult {
+//     let connect_to = join_routine(&ctx, msg).await;
+    
+//     if let Err(ref e) = connect_to {
+//         msg.channel_id
+//            .say(&ctx.http, format!("Failed to join voice channel: {:?}", e))
+//            .await?;
+//     };
+
+//     msg.channel_id
+//        .say(&ctx.http, format!("Joined {}", connect_to.unwrap().voice_chan_id.mention()))
+//        .await?;
+
+//     Ok(())
+// }
+
+// #[command]
+// #[only_in(guilds)]
+// async fn leave(ctx: &Context, msg: &Message) -> CommandResult {
+//     let guild = msg.guild(&ctx.cache).unwrap();
+//     let guild_id = guild.id;
+
+//     let manager = songbird::get(ctx)
+//         .await
+//         .expect("songbird voice client placed in at initialisation.")
+//         .clone();
+
+//     let handler = manager.get(guild_id);
+    
+//     if handler.is_none() {
+//         msg.reply(ctx, "Not in a voice channel").await?;
+//         return Ok(())
+//     }
+    
+//     let handler = handler.unwrap();
+
+//     {
+//         let mut call = handler.lock().await;
+//         call.remove_all_global_events();
+//         call.stop();
+//         let _ = call.deafen(false).await;
+//     }
+
+//     if let Err(e) = manager.remove(guild_id).await {
+//         msg.channel_id
+//            .say(&ctx.http, format!("Failed: {:?}", e))
+//            .await?;
+//     }
+    
+//     {
+//         let mut glob = ctx.data.write().await; 
+//         let queue = glob.get_mut::<crate::LazyQueueKey>().expect("Expected LazyQueueKey in TypeMap");
+//         queue.remove(&guild_id);
+//     }
+
+//     msg.channel_id.say(&ctx.http, "Left voice channel").await?;
+//     Ok(())
+// }
+
+// #[command]
+// #[aliases("play", "p", "q", "add")]
+// #[only_in(guilds)]
+// async fn queue(ctx: &Context, msg: &Message, mut args: Args) -> CommandResult {
+//     let url = match args.single::<String>() {
+//         Ok(url) => url,
+//         Err(_) => {
+//             msg.channel_id
+//                .say(&ctx.http, "Must provide a URL to a video or audio")
+//                .await
+//                .unwrap();
+//             return Ok(());
+//         },
+//     };
+
+//     if !url.starts_with("http") {
+//         msg.channel_id
+//            .say(&ctx.http, "Must provide a valid URL")
+//            .await
+//            .unwrap();
+//         return Ok(());
+//     };
+
+//     let guild = msg.guild(&ctx.cache).unwrap();
+//     let guild_id = guild.id;
+
+//     let manager = songbird::get(ctx)
+//         .await
+//         .expect("Songbird Voice client placed in at initialisation.")
+//         .clone();
+
+//     let qctx: Arc<QueueContext>;
+
+//     let call = match manager.get(guild_id) {
+//         Some(call_lock) => {
+//             qctx = ctx.data.write().await.get_mut::<LazyQueueKey>().unwrap().get_mut(&guild_id).unwrap().clone();
+//             call_lock
+//         },
+        
+//         None => {
+//             let tmp = join_routine(ctx, msg).await;            
+
+//             if let Err(ref e) = tmp {
+//                 msg.channel_id
+//                    .say(&ctx.http, format!("Failed to join voice channel: {:?}", e))
+//                    .await
+//                    .unwrap();        
+//                 return Ok(());
+//             };
+//             qctx = tmp.unwrap();
+//             msg.channel_id
+//                    .say(&ctx.http, format!("Joined: {}", qctx.voice_chan_id.mention()))
+//                    .await
+//                    .unwrap();
+
+//             let call = manager.get(guild_id).ok_or_else(|| JoinError::NoCall);
+//             call?
+//         }
+//     };
+
+//     match Players::from_str(&url)
+//         .ok_or_else(|| String::from("Failed to select extractor for URL"))
+//     {
+//         Ok(player) => {
+//             let mut uris = player.fan_collection(url.as_str()).await?;
+//             let added = uris.len();
+            
+//             // YTDLP singles don't work.
+//             // so instead, use the original URI.
+//             if uris.len() == 1 && player == Players::Ytdl {
+//                 uris.clear();
+//                 uris.push_back(url.clone());
+//             }
+            
+//             qctx.cold_queue.write().await.queue.extend(uris.drain(..));    
+
+//             let maybe_hot = {
+//                 let call = call.lock().await;
+//                 call.queue().len() > 0            
+//             };
+
+//             drop(call); // probably not needed, but just in case
+//             if !maybe_hot {
+//                 uqueue_routine(qctx.clone()).await?;
+//             }
+
+//             let content = format!(
+//                 "Added {} Song(s) [{}] queued",
+//                 added,
+//                 qctx.cold_queue.read().await.queue.len()
+//             );
+            
+//             msg.channel_id            
+//                .say(&ctx.http, &content)
+//                .await?;            
+//         },
+
+//         Err(_) => {
+//             msg.channel_id
+//                .say(&ctx.http, format!("Failed to select extractor for URL: {}", url))
+//                .await?;
+//         }
+//     }
+
+//     Ok(())
+// }
+
+// #[command]
+// #[only_in(guilds)]
+// async fn clear_seeds(ctx: &Context, msg: &Message, args: Args) -> CommandResult {
+//     let guild = msg.guild(&ctx.cache).unwrap();
+//     let guild_id = guild.id;
+
+
+//     let qctx = ctx.data.write().await
+//         .get_mut::<LazyQueueKey>().unwrap()
+//         .get_mut(&guild_id).unwrap().clone();
+
+//     {
+//         let mut cold_queue = qctx.cold_queue.write().await;
+//         cold_queue.seeds.clear();
+//         msg.channel_id.say(&ctx.http, String::from("Cleared.")).await?;
+//     }
+//     Ok(())
+// }
+
+// #[command]
+// #[only_in(guilds)]
+// async fn seeds(ctx: &Context, msg: &Message, args: Args) -> CommandResult {
+//     let guild = msg.guild(&ctx.cache).unwrap();
+//     let guild_id = guild.id;
+
+//     let qctx = ctx.data.write().await
+//         .get_mut::<LazyQueueKey>().unwrap()
+//         .get_mut(&guild_id).unwrap().clone();
+
+//     {
+//         let cold_queue = qctx.cold_queue.read().await;
+//         let seeds = &cold_queue.seeds.range(..)
+//             .cloned().collect::<Vec<_>>().join(", ");
+//         msg.channel_id.say(&ctx.http, format!("Seeds: {}", seeds)).await?;
+//     }
+//     Ok(())
+// }
+
+// #[command]
+// #[only_in(guilds)]
+// async fn skip(ctx: &Context, msg: &Message, args: Args) -> CommandResult {
+//     let guild = msg.guild(&ctx.cache).unwrap();
+//     let guild_id = guild.id;
+    
+//     let qctx = ctx.data.write().await
+//         .get_mut::<LazyQueueKey>().unwrap()
+//         .get_mut(&guild_id).unwrap().clone();
+
+//     let cold_queue_len = qctx.cold_queue.read().await.queue.len();
+     
+//     let skipn = args.remains()
+//         .unwrap_or("1")
+//         .parse::<isize>()
+//         .unwrap_or(1);
+
+//     // stop_event: EventEnd::UnMarked,
+
+//     if 1 > skipn  {
+//         msg.channel_id
+//            .say(&ctx.http, "Must skip at least 1 song")
+//            .await?;
+//         return Ok(())
+//     }
+
+//     else if skipn >= cold_queue_len as isize + 1 {
+//         qctx.cold_queue.write().await.queue.clear();
+//     }
+
+//     else {
+//         let mut cold_queue = qctx.cold_queue.write().await;
+//         let bottom = cold_queue.queue.split_off(skipn as usize - 1);
+//         cold_queue.queue.clear();
+//         cold_queue.queue.extend(bottom);
+//     }
+    
+//     {
+//         let mut cold_queue = qctx.cold_queue.write().await;
+//         if let Some(x) = cold_queue.has_played.front_mut()
+//         {
+//             if let EventEnd::UnMarked = x.stop_event 
+//             {
+//                 x.stop_event = EventEnd::Skipped;
+//                 x.end = Instant::now();
+//             }
+//         }
+//     }
+
+//     let manager = songbird::get(ctx)
+//         .await
+//         .expect("Songbird Voice client placed in at initialisation.")
+//         .clone();
+
+//     match manager.get(guild_id) {
+//         Some(call) => {
+//             let call = call.lock().await;
+//             let queue = call.queue();
+//             let _ = queue.skip();
+//         }
+//         None => {
+//             msg.channel_id
+//                .say(&ctx.http, "Not in a voice channel to play in")
+//                .await?;
+//             return Ok(())
+//         }
+//     };
+
+//     msg.channel_id
+//        .say(
+//             &ctx.http,
+//             format!("Song skipped [{}]: {} in queue.", skipn, cold_queue_len as isize),
+//        )
+//        .await?;
+
+//     Ok(())
+// }

--- a/crates/mockingbird/src/ctrlerror.rs
+++ b/crates/mockingbird/src/ctrlerror.rs
@@ -1,0 +1,66 @@
+use songbird::input::error::Error as SongbirdError;
+
+#[allow(unused_variables)]
+#[derive(Debug)]
+pub enum HandlerError {
+    Songbird(SongbirdError),
+    IOError(std::io::Error),
+    Serenity(serenity::Error),
+    
+    #[cfg(feature = "deemix")]
+    DeemixError(crate::deemix::DeemixError),
+    NotImplemented,
+    NoCall
+}
+
+
+impl From<serenity::Error> for HandlerError {
+    fn from(err: serenity::Error) -> Self {
+        HandlerError::Serenity(err)
+    }
+}
+
+impl From<SongbirdError> for HandlerError {
+    fn from(err: SongbirdError) -> Self {
+        HandlerError::Songbird(err)
+    }
+}
+
+impl From<std::io::Error> for HandlerError {
+    fn from(err: std::io::Error) -> Self {
+        HandlerError::IOError(err)
+    }
+}
+
+#[cfg(feature = "deemix")]
+impl From<crate::deemix::DeemixError> for HandlerError {
+    fn from(err: crate::deemix::DeemixError) -> Self {
+        HandlerError::DeemixError(err)
+    }
+}
+
+impl std::fmt::Display for HandlerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Songbird(err) => write!(f, "Songbird error: {}", err),
+            Self::NotImplemented => write!(f, "This feature is not implemented."),
+            
+            Self::IOError(err)
+                => write!(f, "IO error: (most likely deemix-metadata failed) {}", err),
+            
+            Self::Serenity(err)
+                => write!(f, "Serenity error: {}", err),
+            
+            Self::NoCall
+                => write!(f, "Not in a voice channel to play in"),
+            
+            #[cfg(feature = "deemix")]
+            Self::DeemixError(crate::deemix::DeemixError::BadJson(err))
+                => write!(f, "Deemix error: {}", err),
+
+            _ => write!(f, "Unknown error")
+        }
+    }
+}
+impl std::error::Error for HandlerError {}
+

--- a/crates/mockingbird/src/deemix.rs
+++ b/crates/mockingbird/src/deemix.rs
@@ -278,13 +278,11 @@ pub async fn deemix(
         .await
 }
 
-pub async fn deemix_preload(uri: &str) 
-    -> Result<PreloadInput, DeemixError>
-{
+pub async fn deemix_preload(uri: &str) -> Result<PreloadInput, DeemixError> {
     let pipesize = max_pipe_size().await.expect("Failed to get pipe size");
     _deemix_preload(uri, &[], true, pipesize).await
-
 }
+
 pub async fn _deemix_preload(
     uri: &str,
     pre_args: &[&str],

--- a/crates/mockingbird/src/eventhandler.rs
+++ b/crates/mockingbird/src/eventhandler.rs
@@ -1,0 +1,107 @@
+
+
+
+////// This is only applied to the first track
+// struct DelayRadio(Arc<QueueContext>);
+// #[async_trait]
+// impl VoiceEventHandler for DelayRadio {
+//     async fn act(&self, _ctx: &EventContext<'_>) -> Option<Event> {
+//         // let _ = load_queue(self.0.clone()).await;        
+//         None
+//     }
+// }
+// async fn play<T: AudioPlayer> (play: T, handler: &mut Call) -> Result<(TrackHandle, Option<MetadataType>), HandlerError>
+// {
+//     let (input, metadata) = play.load().await?;
+//     let (track, track_handle) = create_player(input);
+//     handler.enqueue(track);
+//     Ok((track_handle, metadata))
+// }
+// struct TrackEndLoader(Arc<QueueContext>);
+// #[async_trait]
+// impl VoiceEventHandler for TrackEndLoader {
+//     async fn act(&self, _ctx: &EventContext<'_>) -> Option<Event> {
+//         if let Some(call) = self.0.manager.get(self.0.guild_id) {
+//             let mut call = call.lock().await;
+//             let mut cold_queue = self.0.cold_queue.write().await;
+
+//             if call.queue().current().is_none() && cold_queue.queue.is_empty() {
+//                 // if user's play list is empty 
+                    
+//                     // try the preloaded radio track
+//                     if let Some(ref mut radio_preload) = cold_queue.radio_next
+//                     {          
+//                             let preload_result = play_preload(
+//                                 &mut call,
+//                                 &mut radio_preload.children,
+//                                 radio_preload.metadata.clone()
+//                                     .map(|x| x.into())
+//                             ).await;
+                            
+//                             match preload_result {
+//                                 Err(why) =>{        
+//                                     tracing::error!("Failed to play radio track: {}", why);
+//                                     return None
+//                                 }
+//                                 Ok((handle, _)) => {
+//                                     handle.add_event(
+//                                         Event::Delayed(handle.metadata().duration.unwrap() - TS_PRELOAD_OFFSET),
+//                                         PreemptLoader(self.0.clone())
+//                                     ).unwrap();
+
+//                                 }
+//                             }
+
+//                             cold_queue.radio_next = None;
+//                     }
+    
+//                     drop(call);
+//                     drop(cold_queue);
+//             }
+//             else {
+
+//                 cold_queue.radio_queue.clear();
+//                 if let Some(next) = &mut cold_queue.radio_next {
+//                     while let Some(mut pid) = next.children.pop() {
+//                         let _ = pid.kill();
+//                     }
+//                 }
+//                 cold_queue.radio_next = None;
+
+
+//                 drop(cold_queue);
+//                 drop(call);
+//                 let _ = uqueue_routine(self.0.clone()).await;                
+//             }
+//         }
+//         None
+//     }
+// }
+
+// pub struct AbandonedChannel(Arc<QueueContext>);
+// #[async_trait]
+// impl VoiceEventHandler for AbandonedChannel {
+//     async fn act(&self, _ctx: &EventContext<'_>) -> Option<Event> {
+//         let members = self.0.voice_chan_id.members(&self.0.cache).await.unwrap();
+//         if members.iter().filter(|x| !x.user.bot).count() > 0 {
+//             return None;
+//         }
+
+//         leave_routine(
+//             self.0.data.clone(),
+//             self.0.guild_id.clone(),
+//             self.0.manager.clone()
+//         ).await.unwrap();
+
+//         Some(Event::Cancel)
+//     }
+// }
+
+// pub struct PreemptLoader(Arc<QueueContext>);
+// #[async_trait]
+// impl VoiceEventHandler for PreemptLoader {
+//     async fn act(&self, _ctx: &EventContext<'_>) -> Option<Event> {      
+//         // let _ = uqueue_routine(self.0.clone()).await;
+//         None
+//     }
+// }

--- a/crates/mockingbird/src/fan.rs
+++ b/crates/mockingbird/src/fan.rs
@@ -13,7 +13,8 @@ pub struct YtdlUri(pub String);
 pub struct DeemixParser;
 
 
-pub trait LinkParser<T> {
+pub trait LinkParser<T> 
+{
     fn parse_url(uri: &str) -> Option<T>; 
 }
 

--- a/crates/mockingbird/src/fan.rs
+++ b/crates/mockingbird/src/fan.rs
@@ -1,0 +1,106 @@
+use serenity::async_trait;
+use crate::player::MetadataType;
+use crate::ctrlerror::HandlerError;
+use crate::deemix::DeemixMetadata;
+use songbird::input::Metadata;
+use std::collections::VecDeque;
+use std::process::Stdio;
+use tokio::{process::Command, io::AsyncBufReadExt};
+
+
+pub struct DeemixUri(pub String);
+pub struct YtdlUri(pub String);
+pub struct DeemixParser;
+
+
+pub trait LinkParser<T> {
+    fn parse_url(uri: &str) -> Option<T>; 
+}
+
+#[async_trait]
+pub trait FanUri {
+    async fn fan(self, buf: &mut VecDeque<MetadataType>) -> Result<usize, HandlerError>;
+}
+
+impl LinkParser<DeemixUri> for DeemixParser {
+    fn parse_url(uri: &str) -> Option<DeemixUri> {
+        const DEEMIX: [&'static str; 4] = [
+            "deezer.page.link",
+            "deezer.com",
+            "open.spotify",
+            "spotify.link"
+        ];
+
+        if DEEMIX.iter().any(|x| uri.contains(x)) {
+            return Some(DeemixUri(uri.to_owned()))
+        }
+        None
+    }
+}
+
+struct YtdlParser;
+impl LinkParser<YtdlUri> for YtdlParser {
+    fn parse_url(uri: &str) -> Option<YtdlUri> {
+        const YTDL: [&'static str; 4] = [
+            "youtube.com",
+            "youtu.be",
+            "music.youtube.com",
+            "soundcloud.com"
+        ];
+        if YTDL.iter().any(|x|uri.contains(x)) {
+            return Some(YtdlUri(uri.to_owned()))
+        }
+        None
+    }
+}
+
+#[async_trait]
+impl FanUri for DeemixUri {
+    async fn fan(self, buf: &mut VecDeque<MetadataType>) -> Result<usize, HandlerError> {
+        let mut json_buf = Vec::new();
+        let mut err_cnt = 0;
+        
+        metadata_url("deemix-metadata", &[&self.0], &mut json_buf).await?;
+
+        for x in json_buf {
+            let meta = DeemixMetadata::from_deemix_output(&x);
+            buf.push_back(MetadataType::Deemix(meta));
+        }
+
+        Ok(err_cnt)
+    }   
+}
+
+#[async_trait]
+impl FanUri for YtdlUri {
+    async fn fan(self, buf: &mut VecDeque<MetadataType>) -> Result<usize, HandlerError> {
+        let mut json_buf = Vec::new();
+        let mut err_cnt = 0;
+        metadata_url("yt-dlp", &["--flat-playlist", "-j", &self.0], &mut json_buf).await?;
+        
+        for x in json_buf {
+            let meta = Metadata::from_ytdl_output(x);
+            buf.push_back(MetadataType::Standard(meta));
+        }
+
+        // process_fan_output(buf, json_buf, &mut err_cnt, "url");
+        Ok(err_cnt)
+    }
+}
+
+async fn metadata_url(cmd: &str, args: &[&str], buf: &mut Vec<serde_json::Value>) -> std::io::Result<()> {
+    let child = Command::new(cmd)
+        .args(args)
+        .stdout(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    let stdout = child.wait_with_output().await.unwrap();
+    let mut lines = stdout.stdout.lines();
+   
+    while let Some(line) = lines.next_line().await? {
+        let json = serde_json::from_str(&line).unwrap();
+        buf.push(json);
+    } 
+    Ok(())
+}

--- a/crates/mockingbird/src/lib.rs
+++ b/crates/mockingbird/src/lib.rs
@@ -1,5 +1,16 @@
-#[cfg(feature = "controller")]
-#[path = "player.rs"]
+use std::time::Duration;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use serenity::model::id::GuildId;
+use serenity::prelude::*;
+// #[cfg(feature = "controller")]
+pub mod controller;
+
+pub mod routines;
+pub mod fan;
+pub mod ctrlerror;
+
 pub mod player;
 
 #[cfg(feature = "deemix")]
@@ -7,6 +18,17 @@ mod deemix;
 
 #[cfg(feature = "check")]
 pub mod check;
+
+pub const TS_PRELOAD_OFFSET: Duration = Duration::from_secs(20);
+pub const TS_ABANDONED_HB: Duration = Duration::from_secs(720);
+pub const HASPLAYED_MAX_LEN: usize = 10;
+
+type LazyQueue = HashMap<GuildId, Arc<player::QueueContext>>;
+pub struct LazyQueueKey;
+impl TypeMapKey for LazyQueueKey {
+    type Value = LazyQueue;
+}
+
 
 #[cfg(test)]
 mod testsuite;
@@ -18,10 +40,8 @@ pub async fn init(mut cfg: ClientBuilder) -> ClientBuilder {
     use songbird::SerenityInit;
 
 
-    #[cfg(feature = "controller")]
-    {
-        use std::collections::HashMap;
-        cfg = cfg.type_map_insert::<player::LazyQueueKey>(HashMap::new());
+    #[cfg(feature = "controller")] {
+        cfg = cfg.type_map_insert::<LazyQueueKey>(HashMap::new());
     }
 
     cfg.register_songbird()

--- a/crates/mockingbird/src/player.rs
+++ b/crates/mockingbird/src/player.rs
@@ -1,17 +1,14 @@
+// use crate::{routines::{leave_routine}, deemix};
+
 use serenity::{
     async_trait,
-    model::channel::Message,
-    framework::standard::{
-        macros::{command, group},
-        CommandResult, Args,
-    }, 
     client::Cache,
     prelude::*,
-    model::prelude::*, http::Http, json
+    
+    model::prelude::*, http::Http
 };
 
 use songbird::{
-    error::{JoinResult, JoinError},
     events::{Event, EventContext},
     EventHandler as VoiceEventHandler,
     Songbird,
@@ -33,72 +30,201 @@ use songbird::{
 use std::{
     process::Stdio,
     time::{Duration, Instant},
-    collections::VecDeque,
+    collections::{VecDeque, HashSet},
     sync::Arc,
     collections::HashMap,
 };
 
 use tokio::{
-    sync::watch::{Receiver},
     io::AsyncBufReadExt,
     process::Command,
 
 };
 
-
-use crate::deemix::{DeemixMetadata, PreloadInput, _deemix_preload};
-use cutils::{availbytes, bigpipe, max_pipe_size};
-
-const TS_PRELOAD_OFFSET: Duration = Duration::from_secs(20);
-const TS_ABANDONED_HB: Duration = Duration::from_secs(720);
-const HASPLAYED_MAX_LEN: usize = 10;
+use crate::deemix::{DeemixMetadata, PreloadInput};
+use crate::ctrlerror::HandlerError;
+use crate::fan::{DeemixUri, YtdlUri};
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-enum EventEnd {
+pub enum EventEnd {
     Skipped,
     Finished,
     UnMarked
 }
 
+#[derive(Debug, Clone, Copy)]
+pub enum TrackAuthor {
+    Radio,
+    User(UserId)
+}
+
+// -> PreTrackRequest<T>   [prefan]
+//  
+//  -> TrackRequest    [prefan]
+//  -> TrackRequestFetched
+//  -> TrackRequestPreload<T> where T: AudioPlayer
+//  -> magic casting .*.*.~ 
+//  -> TrackRequestPreload<Box<dyn AudioPlayer>>
+
+//  
+// -> TrackRequest         [fan]
+// -> DeemixUri/YtdlUri    [audio-player/preload]
+// -> PreloadInput/PreloadYtdl [audio-player]
+// -> TrackRequestPreload<PreloadInput/PreloadYtdl>
+// 
+// 
+//   -> TrackRequest
+//    -> TrackRequestPreload -> TrackRequestPreload<Box<dyn AudioPlayer>>
+
+
+// trait MetadataTrack<T> {
+//     fn raw_metadata(&self) -> T;
+// }
+pub struct TrackRequest {
+    pub tranid: uuid::Uuid,
+    pub author: TrackAuthor,
+    pub uri: String,
+}
+
+impl TrackRequest {
+    pub fn new(uri: String, author: TrackAuthor) -> Self {
+        Self {
+            tranid: uuid::Uuid::new_v4(),
+            author,
+            uri
+        }
+    }
+    
+    pub fn user(uri: String,  author: UserId) -> Self {
+        Self {
+            tranid: uuid::Uuid::new_v4(),
+            author: TrackAuthor::User(author),
+            uri
+        }
+    }
+
+    pub fn radio(uri: String) -> Self {
+        Self {
+            tranid: uuid::Uuid::new_v4(),
+            author: TrackAuthor::Radio,
+            uri
+        }
+    }
+
+   
+}
+
 #[derive(Debug, Clone)]
-struct TrackRecord {
+pub struct TrackRequestFetched {
+    pub tranid: uuid::Uuid,
+    pub author: TrackAuthor,
+    pub metadata: MetadataType
+}
+impl TrackRequestFetched {
+    pub fn new(tranid: uuid::Uuid, author: TrackAuthor, metadata: MetadataType) -> Self {
+        Self {
+            tranid,
+            author,
+            metadata
+        }
+    }
+}
+
+pub struct TrackRequestPreload<T> {
+    pub input: T,
+    pub request: TrackRequest
+}
+
+impl<T> TrackRequestPreload<T> {
+    async fn new(input: T, req: TrackRequest) -> Result<Self, HandlerError>
+    where T: Preload<T>, 
+          T: Kill
+    {
+        Ok(Self {
+            input: input.preload().await?,
+            request: req
+        })
+    }
+
+    async fn kill(self)
+    where T: Kill
+    {
+        self.input.kill().await;
+    }
+}
+
+#[async_trait]
+impl<T> AudioPlayer for TrackRequestPreload<T>
+where T: AudioPlayer + Send {
+    async fn load(self) -> Result<(Input, Option<MetadataType>), HandlerError> {
+        self.input.load().await
+    }
+} 
+
+impl<T> From<TrackRequestPreload<T>> for TrackRequestPreload<Box<dyn AudioPlayer>>
+where T: AudioPlayer + Send
+{
+    fn from(x: TrackRequestPreload<T>) -> Self {
+        Self {
+            input: Box::new(x.input),
+            request: x.request
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TrackRecord {
     // keep this for spotify recommendations
-    metadata: MetadataType,
-    stop_event: EventEnd,
-    start: Instant,
-    end: Instant,
+    pub req: TrackRequest,
+    pub stop_event: EventEnd,
+    pub start: Instant,
+    pub end: Instant,
 }
 
-struct ColdQueue {
-    pub queue: VecDeque<String>,
+pub struct Radio {
+    pub suggestions: VecDeque<TrackRequestFetched>,
+    pub seeds: VecDeque<MetadataType>,
+}
+
+pub struct Queue {
+    pub cold: VecDeque<TrackRequestFetched>,
+    pub warm: VecDeque<TrackRequestPreload<Box<dyn AudioPlayer>>>,
+    
     pub has_played: VecDeque<TrackRecord>,
+    pub past_transactions: VecDeque<uuid::Uuid>,
 
-    // urls
-    pub radio_queue: VecDeque<String>,
-    pub radio_next: Option<PreloadInput>,
+    pub killed: Vec<std::process::Child>,
+    pub radio: Option<Radio>,
 }
 
-type LazyQueue = HashMap<GuildId, Arc<QueueContext>>;
-pub struct LazyQueueKey;
-impl TypeMapKey for LazyQueueKey {
-    type Value = LazyQueue;
-}
-
+// Dont break up this structure into smaller pieces
+// It is accessed via a global lock, and would require
+// multiple open locks to access
+// keeping it as one structure reduces the number of locks
 pub struct QueueContext {
-    guild_id: GuildId,
-    invited_from: ChannelId,
-    voice_chan_id: GuildChannel,
-    cache: Arc<Cache>,
-    data: Arc<RwLock<TypeMap>>,
-    http: Arc<Http>,
-    manager: Arc<Songbird>,
-    cold_queue: Arc<RwLock<ColdQueue>>,
+    pub guild_id: GuildId,
+    pub invited_from: ChannelId,
+    pub voice_chan_id: GuildChannel,
+    pub cache: Arc<Cache>,
+ 
+    // pub data: Arc<RwLock<TypeMap>>,
+    pub http: Arc<Http>,
+    pub queue: Queue,
+    
+    //avoid    
+    pub manager: Arc<Songbird>,
 }
+
+struct Fetched {
+    inner: MetadataType,   
+    from_request_id: uuid::Uuid,
+}
+
+
 #[derive(Debug, Clone)]
-enum MetadataType {
+pub enum MetadataType {
     #[cfg(feature = "deemix")]
     Deemix(crate::deemix::DeemixMetadata),
-    
     Standard(Metadata),
 }
 
@@ -126,941 +252,102 @@ impl From<crate::deemix::DeemixMetadata> for MetadataType {
     }
 }
 
-#[group]
-#[commands(join, leave, queue, now_playing, skip)]
-struct BetterPlayer;
-
-async fn next_track(call: &mut Call, uri: &str) -> Result<(TrackHandle, Option<MetadataType>), HandlerError> {
-    let player = Players::from_str(&uri)
-        .ok_or_else(|| HandlerError::NotImplemented)?;
-    
-    player.play(call, &uri).await
-}
-
-struct TrackEndLoader(Arc<QueueContext>);
-#[async_trait]
-impl VoiceEventHandler for TrackEndLoader {
-    async fn act(&self, _ctx: &EventContext<'_>) -> Option<Event> {
-        if let Some(call) = self.0.manager.get(self.0.guild_id) {
-            let mut call = call.lock().await;
-            let mut cold_queue = self.0.cold_queue.write().await;
-
-            if call.queue().current().is_none() {
-                // if user's play list is empty 
-                if cold_queue.queue.is_empty() {
-                
-                // try the preloaded radio track
-                if let Some(ref mut radio_preload) = cold_queue.radio_next {          
-                        let preload_result = Players::play_preload(
-                            &mut call,
-                            &mut radio_preload.children,
-                            radio_preload.metadata.clone()
-                                .map(|x| x.into())
-                        ).await;
-                        
-                        match preload_result {
-                            Err(why) =>{        
-                                tracing::error!("Failed to play radio track: {}", why);
-                                return None
-                            }
-                            Ok((handle, _)) => {
-                                handle.add_event(
-                                    Event::Delayed(handle.metadata().duration.unwrap() - TS_PRELOAD_OFFSET),
-                                    PreemptLoader(self.0.clone())
-                                ).unwrap();
-
-                            }
-                        }
-
-                        cold_queue.radio_next = None;
-                    }
-                }
-                drop(call);
-                drop(cold_queue);
-            }
-            else {
-                cold_queue.radio_queue.clear();
-                cold_queue.radio_next = None;
-
-                drop(cold_queue);
-                drop(call);
-                
-                let _ = play_routine(self.0.clone()).await;                
-            }
-            
-            let mut cold_queue = self.0.cold_queue.write().await;
-            let mut tries = 5;
-            loop {
-                let uri = match cold_queue.radio_queue.pop_front() {
-                    Some(x) => Some(x),
-
-                    None => {
-                        let has_played = &cold_queue.has_played;
-                        let seeds = has_played.iter()
-                            .filter(|x| x.stop_event != EventEnd::Skipped)
-                            .filter_map(|x| 
-                                match &x.metadata {
-                                    MetadataType::Deemix(meta) 
-                                        => meta.isrc.clone(),
-                                        _ => None
-                                }
-                            )
-                            .collect::<Vec<_>>();
-                        
-                        if seeds.is_empty() {
-                            return None
-                        }
-                        
-                        let generated = recommend(&seeds, 5).await.unwrap();
-                        if generated.is_empty() { return None }
-
-                        cold_queue.radio_queue = generated;
-                        cold_queue.radio_queue.pop_front()                
-                    }
-                };
-
-                match uri {
-                    Some(x) => {
-                        let pipesize = max_pipe_size().await;
-                        match _deemix_preload(
-                            &x,
-                            &[],
-                            true,
-                            pipesize.unwrap()    
-                        ).await
-                        {
-                            Ok(preload_input) => {
-                                cold_queue.radio_next = Some(preload_input);
-                                break
-                            }
-                            Err(why) =>  {
-                                
-                                tries -= 1;
-                                tracing::error!("Error preloading radio track: {}", why);   
-                                
-                                if 0 >= tries {
-                                    break;
-                                }
-                                continue
-                            }
-                        }
-                    }
-                    None => return None
-                }
-            }
-        }
-        None
-    }
-}
-
-struct AbandonedChannel(Arc<QueueContext>);
-#[async_trait]
-impl VoiceEventHandler for AbandonedChannel {
-    async fn act(&self, _ctx: &EventContext<'_>) -> Option<Event> {
-        let members = self.0.voice_chan_id.members(&self.0.cache).await.unwrap();
-        if members.iter().filter(|x| !x.user.bot).count() > 0 {
-            return None;
-        }
-
-        leave_routine(
-            self.0.data.clone(),
-            self.0.guild_id.clone(),
-            self.0.manager.clone()
-        ).await.unwrap();
-
-        Some(Event::Cancel)
-    }
-}
-
-struct PreemptLoader(Arc<QueueContext>);
-#[async_trait]
-impl VoiceEventHandler for PreemptLoader {
-    async fn act(&self, _ctx: &EventContext<'_>) -> Option<Event> {      
-        let _ = play_routine(self.0.clone()).await;
-        None
-    }
-}
-
-#[allow(unused_variables)]
-#[derive(Debug)]
-enum HandlerError {
-    Songbird(SongbirdError),
-    IOError(std::io::Error),
-    Serenity(serenity::Error),
-    
-    #[cfg(feature = "deemix")]
-    DeemixError(crate::deemix::DeemixError),
-    
-    NotImplemented,
-    NoCall
-}
-
-impl From<serenity::Error> for HandlerError {
-    fn from(err: serenity::Error) -> Self {
-        HandlerError::Serenity(err)
-    }
-}
-
-impl From<SongbirdError> for HandlerError {
-    fn from(err: SongbirdError) -> Self {
-        HandlerError::Songbird(err)
-    }
-}
-
-impl From<std::io::Error> for HandlerError {
-    fn from(err: std::io::Error) -> Self {
-        HandlerError::IOError(err)
-    }
-}
-
-#[cfg(feature = "deemix")]
-impl From<crate::deemix::DeemixError> for HandlerError {
-    fn from(err: crate::deemix::DeemixError) -> Self {
-        HandlerError::DeemixError(err)
-    }
-}
-
-impl std::fmt::Display for HandlerError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl MetadataType {
+    pub fn source_url(&self) -> Option<String> {
         match self {
-            Self::Songbird(err) => write!(f, "Songbird error: {}", err),
-            Self::NotImplemented => write!(f, "This feature is not implemented."),
-            
-            Self::IOError(err)
-                => write!(f, "IO error: (most likely deemix-metadata failed) {}", err),
-            
-            Self::Serenity(err)
-                => write!(f, "Serenity error: {}", err),
-            
-            Self::NoCall
-                => write!(f, "Not in a voice channel to play in"),
-            
+            Self::Standard(meta) => meta.source_url.clone(),            
             #[cfg(feature = "deemix")]
-            Self::DeemixError(crate::deemix::DeemixError::BadJson(err))
-                => write!(f, "Deemix error: {}", err),
-
-            _ => write!(f, "Unknown error")
+            Self::Deemix(meta) => meta.metadata.source_url.clone()
         }
     }
 }
-impl std::error::Error for HandlerError {}
 
-fn process_fan_output(buf: &mut VecDeque<String>, json_buf: Vec<serde_json::Value>, err_cnt: &mut usize, key: &str){
-    for x in json_buf {
-        if let Some(jmap) = x.as_object() {
-            if !jmap.contains_key(key) {
-                tracing::error!("{} not found in json", key);
-                *err_cnt += 1;
-                continue
-            }
-        
-            buf.push_back(jmap[key].as_str().unwrap().to_owned());
-        }
-        else {
-
-            tracing::error!("{} not found in json", key);
-            *err_cnt += 1;
-            continue
-        }
-    }
-    tracing::info!("{} tracks found", buf.len());
+#[async_trait]
+pub trait AudioPlayer: Send + Sync {
+    async fn load(self) -> Result<(Input, Option<MetadataType>), HandlerError>;
 }
 
-/*
- * Some ugly place holders for
- * feature generated code.
-*/
-#[cfg(feature="deemix")]
-async fn fan_deezer(uri: &str, buf: &mut VecDeque<String>) -> Result<usize, HandlerError> {
-    let mut json_buf = Vec::new();
-    let mut err_cnt = 0;
-    _urls("deemix-metadata", &[uri], &mut json_buf).await?;
-
-    process_fan_output(buf, json_buf, &mut err_cnt, "link");
-    Ok(err_cnt)
-}
-
-#[cfg(feature="ytdl")]
-async fn fan_ytdl(uri: &str, buf: &mut VecDeque<String>) -> Result<usize, HandlerError> {
-    let mut json_buf = Vec::new();
-    let mut err_cnt = 0;
-    _urls("yt-dlp", &["--flat-playlist", "-j", uri], &mut json_buf).await?;
-    
-    process_fan_output(buf, json_buf, &mut err_cnt, "url");
-    Ok(err_cnt)
-}
-
-#[cfg(not(feature="deemix"))]
-async fn fan_deezer(uri: &str, buf: &mut VecDeque<String>) -> Result<(), HandlerError>  {
-    return Err(HandlerError::NotImplemented)
-}
-
-#[cfg(not(feature="ytdl"))]
-async fn fan_ytdl(uri: &str, buf: &mut VecDeque<String>) -> Result<usize, HandlerError> {
-    return Err(HandlerError::NotImplemented)
-}
-
-#[cfg(feature = "deemix")]
-async fn ph_deemix_player(uri: &str, balloon: bool) -> Result<(Input, Option<MetadataType>), HandlerError> {
-    crate::deemix::deemix(uri, balloon).await
-        .map_err(HandlerError::from)
-        .map(|(input, meta)| (input, meta.map(|x| x.into())))   
-    }
-
-#[cfg(feature = "ytdl")]
-async fn ph_ytdl_player(uri: &str) -> Result<(Input, Option<MetadataType>), HandlerError> {
-    return songbird::ytdl(uri).await.map_err(HandlerError::from)
-        .map(|input| (input, None))
-}
-
-#[cfg(not(feature = "deemix"))]
-struct FakeMeta(Metadata);
-
-#[cfg(not(feature = "deemix"))]
-impl Into<Metadata> for FakeMeta {
-    fn into(self) -> Metadata {
-        self.0
-    }
-}
-
-#[cfg(not(feature = "deemix"))]
-async fn ph_deemix_player(uri: &str) -> Result<(Input, Option<FakeMeta>), HandlerError> {
-    return Err(HandlerError::NotImplemented)
-}
-
-#[cfg(not(feature = "ytdl"))]
-async fn ph_ytdl_player(uri: &str) -> Result<(Input, Option<MetadataType>), HandlerError> {
-    return Err(HandlerError::NotImplemented)
-}
-
-async fn _urls(cmd: &str, args: &[&str], buf: &mut Vec<serde_json::Value>) -> std::io::Result<()> {
-    let child = Command::new(cmd)
-        .args(args)
-        .stdout(Stdio::piped())
-        .spawn()
-        .unwrap();
-
-    let stdout = child.wait_with_output().await.unwrap();
-    let mut lines = stdout.stdout.lines();
-   
-    while let Some(line) = lines.next_line().await? {
-        let json = serde_json::from_str(&line).unwrap();
-        buf.push(json);
-    } 
-    Ok(())
-}
-
-async fn recommend(isrcs: &Vec<String>, limit: u8) -> std::io::Result<VecDeque<String>> {
-    let mut buffer = std::collections::HashSet::new();
-
-    tracing::info!("running spotify-recommend -l {} {}", limit, isrcs.join(" "));
-    let recommend = tokio::process::Command::new("spotify-recommend")
-        .arg("-l")
-        .arg(format!("{}", limit))
-        .args(isrcs.iter())
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()?;
-    
-    let output = recommend.wait_with_output()
-        .await?;
-    
-    let mut lines = output.stdout.lines();
-    
-    while let Some(x) = lines.next_line().await? {
-        buffer.insert(x);
-    }
-    tracing::info!("spotify-stream finished [{}]", buffer.len());
-    let mut ret = VecDeque::new();
-    for x in buffer {
-        ret.push_back(x);   
-    }
-    Ok(ret)
-}
-
-#[derive(PartialEq, Eq)]
-enum Players {
-    Ytdl,
-    Deemix,
-}
-
-impl Players {
-    fn from_str(data : &str) -> Option<Self>
+#[async_trait]
+impl AudioPlayer for DeemixUri {
+    async fn load(self) -> Result<(Input, Option<MetadataType>), HandlerError>
     {
-        const DEEMIX: [&'static str; 4] = ["deezer.page.link", "deezer.com", "open.spotify", "spotify.link"];
-        const YTDL: [&'static str; 4] = ["youtube.com", "youtu.be", "music.youtube.com", "soundcloud.com"];
-
-        if DEEMIX.iter().any(|x|data.contains(x)) { return Some(Self::Deemix) }
-        else if YTDL.iter().any(|x|data.contains(x)) {return Some(Self::Ytdl) }
-        else { return None }
+        crate::deemix::deemix(&self.0, true).await
+            .map_err(HandlerError::from)
+            .map(|(input, meta)| (input, meta.map(|x| x.into())))
     }
+}
 
-    async fn play(&self, handler: &mut Call, uri: &str) -> Result<(TrackHandle, Option<MetadataType>), HandlerError>
+#[async_trait]
+impl AudioPlayer for YtdlUri {
+    async fn load(mut self) -> Result<(Input, Option<MetadataType>), HandlerError>
     {
-        let (input, metadata) = match self {
-            Self::Deemix => ph_deemix_player(uri, false).await,
-            Self::Ytdl => ph_ytdl_player(uri).await
-        }?;
-
-        let (track, track_handle) = create_player(input);
-        handler.enqueue(track);
-
-        Ok((track_handle, metadata))
+        songbird::ytdl(&self.0).await
+            .map_err(HandlerError::from)
+            .map(|input| (input, None))
     }
+}
 
-    async fn play_preload(
-        handler: &mut Call,
-        children:&mut Vec<std::process::Child>,
-        metadata: Option<MetadataType>
-    )
-    -> Result<(TrackHandle, Option<MetadataType>), HandlerError>
+#[async_trait]
+impl AudioPlayer for PreloadInput {
+    async fn load(mut self) -> Result<(Input, Option<MetadataType>), HandlerError>
     {
-        let input = Input::new(
+        Ok((Input::new(
             true, 
-            children_to_reader::<f32>(children.drain(..).collect()),
+            children_to_reader::<f32>(self.children.drain(..).collect()),
             Codec::FloatPcm,
             Container::Raw,
-            metadata.clone().map(|x| x.into())
-        );
-
-        let (track, track_handle) = create_player(input);
-        handler.enqueue(track);
-
-        Ok((track_handle, metadata))
+        self.metadata.clone().map(|x| x.into())), self.metadata.map(|x| x.into())))
     }
-
-    async fn fan_collection(&self, uri: &str) -> Result<VecDeque<String>, HandlerError> {
-        let mut buf = VecDeque::new();
-        match self {
-            Self::Deemix => fan_deezer(uri, &mut buf).await,
-            Self::Ytdl => fan_ytdl(uri, &mut buf).await 
-        }?;
-        return Ok(buf)
+}
+///dont pass around Input internally, it doesn't meet the trait bounds
+#[async_trait]
+impl AudioPlayer for PreloadYtdl {
+    async fn load(self) -> Result<(Input, Option<MetadataType>), HandlerError> {
+        Ok((self.0, None))
     }
 }
 
-async fn play_routine(qctx: Arc<QueueContext>) -> Result<(), HandlerError> {
-    let mut tries = 4;
-    let handler = qctx.manager.get(qctx.guild_id)
-        .ok_or_else(|| HandlerError::NoCall)?;
-    
-    let mut call = handler.lock().await;
-    let mut cold_queue = qctx.cold_queue.write().await;
-
-    while let Some(uri) = cold_queue.queue.pop_front() {
-        match next_track(&mut call, &uri).await {
-            Ok((track, metadata)) => {
-                if cold_queue.has_played.len() > HASPLAYED_MAX_LEN {
-                    let _ = cold_queue.has_played.pop_back();
-                }
-
-                if let Some(x) = cold_queue.has_played.front_mut() {
-                    if let EventEnd::UnMarked = x.stop_event {
-                        x.stop_event = EventEnd::Finished;
-                        x.end = Instant::now();
-                    }
-                }
-                
-                let data = TrackRecord {
-                    metadata: metadata.unwrap_or(MetadataType::from(track.metadata().clone())),
-                    stop_event: EventEnd::UnMarked,
-                    start: Instant::now(),
-                    end: Instant::now(),
-                };
-
-                cold_queue.has_played.push_front(data);
-            
-                track.add_event(
-                    Event::Delayed(track.metadata().duration.unwrap() - TS_PRELOAD_OFFSET),
-                    PreemptLoader(qctx.clone())
-                ).unwrap();
-
-                break
-            },
-            Err(e) => {
-                tracing::error!("Failed to play next track: {}", e);
-                
-                let response = match e {
-                    HandlerError::NotImplemented 
-                        => "Not implemented/enabled".to_string(),
-                    
-                    HandlerError::NoCall 
-                        => "No call found".to_string(),
-                    
-                    HandlerError::IOError(e) 
-                        => format!("IO Error: {}", e.kind()),
-                    
-                    #[cfg(feature = "deemix")]
-                    HandlerError::DeemixError(crate::deemix::DeemixError::BadJson(text))
-                        => {
-                            qctx.invited_from.send_files(
-                                &qctx.http,
-                                vec![ (text.as_bytes(), "error.txt") ],
-                                |m| m
-                            ).await?;
-                            "Json Error".to_string()
-                        }
-                    
-                    e => format!("Discord error: {}", e)
-                };
-
-                if tries == 0 {
-                    let _ = qctx.invited_from
-                        .say(&qctx.http, format!("Halting. Last try: {}", &uri))
-                        .await;
-                    break
-                }
-
-                let _ = qctx.invited_from
-                    .say(&qctx.http, format!("Couldn't play track {}\n{}", &uri, &response))
-                    .await;
-
-                tries -= 1;
-            }
-        }
-    }
-    Ok(())
+#[async_trait]
+pub trait Kill {
+    async fn kill(self) -> Result<(), HandlerError>;
 }
 
-async fn leave_routine (
-    data: Arc<RwLock<TypeMap>>,
-    guild_id: GuildId,
-    manager: Arc<Songbird>
-) -> JoinResult<()>
-{   
-    let handler = manager.get(guild_id).unwrap();
-
-    {
-        let mut call = handler.lock().await;
-        call.remove_all_global_events();
-        call.stop();
-    }    
-    
-    manager.remove(guild_id).await?;
-
-    {
-        let mut glob = data.write().await; 
-        let queue = glob.get_mut::<LazyQueueKey>()
-            .expect("Expected LazyQueueKey in TypeMap");
-        queue.remove(&guild_id);
-    }
-
-    Ok(())
+#[async_trait]
+pub trait Preload<T> {
+    async fn preload(self) -> Result<T, HandlerError>;
 }
 
-async fn join_routine(ctx: &Context, msg: &Message) -> Result<Arc<QueueContext>, JoinError> {
-    let guild = msg.guild(&ctx.cache).unwrap();
-    let guild_id = guild.id;
-
-    let channel_id = guild
-        .voice_states
-        .get(&msg.author.id)
-        .and_then(|voice_state| voice_state.channel_id);
-
-    let connect_to = match channel_id {
-        Some(channel) => channel,
-        None => {
-            msg.reply(&ctx.http, "Not in a voice channel").await.unwrap();
-            return Err(JoinError::NoCall);
-        },
-    };
-
-    let chan: Channel = connect_to.to_channel(&ctx.http).await.unwrap();
-
-    let gchan = match chan {
-        Channel::Guild(ref gchan) => gchan,
-        _ => {
-            msg.reply(
-              &ctx.http,
-              "Not supported voice channel"
-            ).await
-             .unwrap();
-
-            return Err(JoinError::NoCall);
-        }
-    };
-
-    match gchan.bitrate {
-       Some(x) if x > 90_000 => {}
-       None => {
-           let _ = msg.reply(
-               &ctx.http,
-               r#"**Couldn't detect bitrate.** For the best experience,
-                  check that the voice room is using 128kbps."#
-           ).await;
-       }
-       Some(x) => {
-            #[cfg(feature = "deemix")]
-            let _ = msg.reply(
-                &ctx,
-                format!(
-                    r#"**Low quality voice room** detected.
-
-                    For the best experience, use 128kbps, & spotify links 
-                    [Currently: {}kbps]"#,
-                    (x / 1000)
-                )
-            ).await;
-        }
-    }
-    
-    let manager = songbird::get(ctx)
-        .await
-        .expect("Songbird Voice client placed in at initialisation.")
-        .clone();
-
-    let (_handle_lock, success) = manager.join(guild_id, connect_to).await;
-
-    if let Err(e) = success {
-        return Err(e);
-    }
-    
-    let call_lock = manager.get(guild_id).unwrap(); 
-    let mut call = call_lock.lock().await;
-
-    let queuectx =
-        if let Channel::Guild(voice_chan_id) = chan {
-            QueueContext {
-                guild_id,
-                voice_chan_id,
-                invited_from: msg.channel_id,
-                cache: ctx.cache.clone(),
-                data: ctx.data.clone(),
-                manager: manager.clone(),
-                http: ctx.http.clone(),
-                cold_queue: Arc::new(RwLock::new(ColdQueue {
-                    queue: VecDeque::new(),
-                    has_played: VecDeque::new(),
-                    radio_next: None,
-                    radio_queue: VecDeque::new(),
-                })),
-            }
-        } else {
-            tracing::error!("Expected voice channel (GuildChannel), got {:?}", chan);
-            return Err(JoinError::NoCall);
-        };
-
-    
-    let queuectx = Arc::new(queuectx);
-    
-    {
-        let mut glob = ctx.data.write().await; 
-        let queue = glob.get_mut::<LazyQueueKey>()
-            .expect("Expected LazyQueueKey in TypeMap");
-        queue.insert(guild_id, queuectx.clone());
-    }
-
-    let _ = call.deafen(true).await;
-    
-    call.add_global_event(
-        Event::Track(TrackEvent::End),
-        TrackEndLoader(queuectx.clone())
-    );
-    
-    call.add_global_event(
-        Event::Periodic(TS_ABANDONED_HB, None),
-        AbandonedChannel(queuectx.clone())
-    );
-
-    Ok(queuectx)
+#[async_trait]
+impl Preload<PreloadInput> for DeemixUri {
+    async fn preload(self) ->  Result<PreloadInput, HandlerError> {
+        crate::deemix::deemix_preload(&self.0).await
+            .map_err(HandlerError::from)
+    } 
 }
 
-#[command]
-#[aliases("np", "playing", "now-playing", "playing-now", "nowplaying")]
-#[only_in(guilds)]
-async fn now_playing(ctx: &Context, msg: &Message) -> CommandResult {
-    let guild = msg.guild(&ctx.cache).unwrap();
-    let guild_id = guild.id;
-
-    let qctx = {
-        let mut glob = ctx.data.write().await;
-        let queue = glob.get_mut::<LazyQueueKey>()
-            .expect("Expected LazyQueueKey in TypeMap");
-        queue.get(&guild_id).cloned()
-    };
-
-    let qctx = match qctx {
-        Some(qctx) => qctx,
-        None => {
-            msg.channel_id
-               .say(&ctx.http, "Not in a voice channel")
-               .await?;
-            return Ok(());
-        }
-    };
-
-    let call_lock = qctx.manager
-        .get(qctx.guild_id)
-        .unwrap();
-
-    let call = call_lock.lock().await;
-
-    match call.queue().current() {
-        Some(ref x) => {
-            msg.channel_id
-               .say(&ctx.http,
-                    format!(
-                        "{}: {}", qctx.voice_chan_id.mention(),
-                        x.metadata()
-                            .clone()
-                            .source_url
-                            .unwrap_or("Unknown".to_string())
-                    )
-               ).await?;
-        }
-        None => {
-            msg.channel_id
-               .say(&ctx.http, "Nothing is currently playing")
-               .await?;
-        }
-    }
-
-    Ok(())
+/// ytdl doesn't need preloading.
+#[async_trait]
+impl Preload<YtdlUri> for YtdlUri {
+    async fn preload(self) ->  Result<YtdlUri, HandlerError> {
+        Ok(self)
+    } 
 }
 
-#[command]
-#[only_in(guilds)]
-async fn join(ctx: &Context, msg: &Message) -> CommandResult {
-    let connect_to = join_routine(&ctx, msg).await;
-    
-    if let Err(ref e) = connect_to {
-        msg.channel_id
-           .say(&ctx.http, format!("Failed to join voice channel: {:?}", e))
-           .await?;        
+#[async_trait]
+impl Kill for PreloadInput {
+    async fn kill(self) -> Result<(), HandlerError> {
+        for mut pid in self.children {
+            let _ = pid.kill();
+        }       
+        Ok(())
     }
-
-    msg.channel_id
-       .say(&ctx.http, format!("Joined {}", connect_to.unwrap().voice_chan_id.mention()))
-       .await?;
-
-    Ok(())
 }
 
-#[command]
-#[only_in(guilds)]
-async fn leave(ctx: &Context, msg: &Message) -> CommandResult {
-    let guild = msg.guild(&ctx.cache).unwrap();
-    let guild_id = guild.id;
-
-    let manager = songbird::get(ctx)
-        .await
-        .expect("songbird voice client placed in at initialisation.")
-        .clone();
-
-    let handler = manager.get(guild_id);
-    
-    if handler.is_none() {
-        msg.reply(ctx, "Not in a voice channel").await?;
-        return Ok(())
+#[async_trait]
+impl Preload<PreloadYtdl> for YtdlUri {
+    async fn preload(self) ->  Result<PreloadYtdl, HandlerError> {
+        songbird::ytdl(&self.0).await
+            .map_err(HandlerError::from)
+            .map(|input| PreloadYtdl(input))
     }
-    
-    let handler = handler.unwrap();
-
-    {
-        let mut call = handler.lock().await;
-        call.remove_all_global_events();
-        call.stop();
-        let _ = call.deafen(false).await;
-    }
-
-    if let Err(e) = manager.remove(guild_id).await {
-        msg.channel_id
-           .say(&ctx.http, format!("Failed: {:?}", e))
-           .await?;
-    }
-    
-    {
-        let mut glob = ctx.data.write().await; 
-        let queue = glob.get_mut::<LazyQueueKey>().expect("Expected LazyQueueKey in TypeMap");
-        queue.remove(&guild_id);
-    }
-
-    msg.channel_id.say(&ctx.http, "Left voice channel").await?;
-    Ok(())
-}
-
-#[command]
-#[aliases("play", "p", "q")]
-#[only_in(guilds)]
-async fn queue(ctx: &Context, msg: &Message, mut args: Args) -> CommandResult {
-    let url = match args.single::<String>() {
-        Ok(url) => url,
-        Err(_) => {
-            msg.channel_id
-               .say(&ctx.http, "Must provide a URL to a video or audio")
-               .await
-               .unwrap();
-            return Ok(());
-        },
-    };
-
-    if !url.starts_with("http") {
-        msg.channel_id
-           .say(&ctx.http, "Must provide a valid URL")
-           .await
-           .unwrap();
-        return Ok(());
-    };
-
-    let guild = msg.guild(&ctx.cache).unwrap();
-    let guild_id = guild.id;
-
-    let manager = songbird::get(ctx)
-        .await
-        .expect("Songbird Voice client placed in at initialisation.")
-        .clone();
-
-    let qctx: Arc<QueueContext>;
-
-    let call = match manager.get(guild_id) {
-        Some(call_lock) => {
-            qctx = ctx.data.write().await.get_mut::<LazyQueueKey>().unwrap().get_mut(&guild_id).unwrap().clone();
-            call_lock
-        },
-        
-        None => {
-            let tmp = join_routine(ctx, msg).await;            
-
-            if let Err(ref e) = tmp {
-                msg.channel_id
-                   .say(&ctx.http, format!("Failed to join voice channel: {:?}", e))
-                   .await
-                   .unwrap();        
-                return Ok(());
-            };
-            qctx = tmp.unwrap();
-            msg.channel_id
-                   .say(&ctx.http, format!("Joined: {}", qctx.voice_chan_id.mention()))
-                   .await
-                   .unwrap();
-
-            let call = manager.get(guild_id).ok_or_else(|| JoinError::NoCall);
-            call?
-        }
-    };
-
-    match Players::from_str(&url)
-        .ok_or_else(|| String::from("Failed to select extractor for URL"))
-    {
-        Ok(player) => {
-            let mut uris = player.fan_collection(url.as_str()).await?;
-            let added = uris.len();
-            
-            // YTDLP singles don't work.
-            // so instead, use the original URI.
-            if uris.len() == 1 && player == Players::Ytdl {
-                uris.clear();
-                uris.push_back(url.clone());
-            }
-            
-            qctx.cold_queue.write().await.queue.extend(uris.drain(..));    
-
-            let maybe_hot = {
-                let call = call.lock().await;
-                call.queue().len() > 0            
-            };
-
-            drop(call); // probably not needed, but just in case
-            if !maybe_hot {
-                play_routine(qctx.clone()).await?;
-            }
-
-            let content = format!(
-                "Added {} Song(s) [{}] queued",
-                added,
-                qctx.cold_queue.read().await.queue.len()
-            );
-            
-            msg.channel_id            
-               .say(&ctx.http, &content)
-               .await?;            
-        },
-
-        Err(_) => {
-            msg.channel_id
-               .say(&ctx.http, format!("Failed to select extractor for URL: {}", url))
-               .await?;
-        }
-    }
-
-    Ok(())
-}
-
-#[command]
-#[only_in(guilds)]
-async fn skip(ctx: &Context, msg: &Message, args: Args) -> CommandResult {
-    let guild = msg.guild(&ctx.cache).unwrap();
-    let guild_id = guild.id;
-    
-    let qctx = ctx.data.write().await
-        .get_mut::<LazyQueueKey>().unwrap()
-        .get_mut(&guild_id).unwrap().clone();
-
-    let cold_queue_len = qctx.cold_queue.read().await.queue.len();
-     
-    let skipn = args.remains()
-        .unwrap_or("1")
-        .parse::<isize>()
-        .unwrap_or(1);
-
-    // stop_event: EventEnd::UnMarked,
-
-    if 1 > skipn  {
-        msg.channel_id
-           .say(&ctx.http, "Must skip at least 1 song")
-           .await?;
-        return Ok(())
-    }
-
-    else if skipn >= cold_queue_len as isize + 1 {
-        qctx.cold_queue.write().await.queue.clear();
-    }
-
-    else {
-        let mut cold_queue = qctx.cold_queue.write().await;
-        let bottom = cold_queue.queue.split_off(skipn as usize - 1);
-        cold_queue.queue.clear();
-        cold_queue.queue.extend(bottom);
-    }
-    
-    {
-        let mut cold_queue = qctx.cold_queue.write().await;
-        if let Some(x) = cold_queue.has_played.front_mut()
-        {
-            if let EventEnd::UnMarked = x.stop_event 
-            {
-                x.stop_event = EventEnd::Skipped;
-                x.end = Instant::now();
-            }
-        }
-    }
-
-    let manager = songbird::get(ctx)
-        .await
-        .expect("Songbird Voice client placed in at initialisation.")
-        .clone();
-
-    match manager.get(guild_id) {
-        Some(call) => {
-            let call = call.lock().await;
-            let queue = call.queue();
-            let _ = queue.skip();
-        }
-        None => {
-            msg.channel_id
-               .say(&ctx.http, "Not in a voice channel to play in")
-               .await?;
-            return Ok(())
-        }
-    };
-
-    msg.channel_id
-       .say(
-            &ctx.http,
-            format!("Song skipped [{}]: {} in queue.", skipn, skipn-cold_queue_len as isize),
-       )
-       .await?;
-
-    Ok(())
 }

--- a/crates/mockingbird/src/routines.rs
+++ b/crates/mockingbird/src/routines.rs
@@ -1,0 +1,328 @@
+
+use serenity::{
+    async_trait,
+    model::channel::Message,
+    framework::standard::{
+        macros::{command, group},
+        CommandResult, Args,
+    }, 
+    client::Cache,
+    prelude::*,
+    
+    model::prelude::*, http::{Http, request::Request}, json
+};
+
+use serenity::futures::StreamExt;
+
+use songbird::{
+    error::{JoinResult, JoinError},
+    events::{Event, EventContext},
+    EventHandler as VoiceEventHandler,
+    Songbird,
+    Call, 
+    create_player,
+    tracks::{TrackHandle, Track},
+
+    TrackEvent
+};
+
+use std::{
+    time::{Instant},
+    collections::{VecDeque, HashSet},
+    sync::Arc,
+};
+
+use cutils::{availbytes, bigpipe, max_pipe_size};
+
+use crate::{deemix::{DeemixMetadata, PreloadInput, DeemixError}, player::TrackRequestPreload};
+
+use crate::player::{Queue, AudioPlayer, MetadataType, QueueContext, TrackRecord, EventEnd, TrackRequest};
+use crate::ctrlerror::HandlerError;
+
+
+async fn next_track(queue: &mut VecDeque<TrackRequestPreload<Box<dyn AudioPlayer + Send>>> )
+    -> Option<Box<dyn AudioPlayer + Send>> {
+    
+    let (mut radio, mut user): (VecDeque<_>, VecDeque<_>) = queue.iter().partition(|x|
+        if let crate::player::TrackAuthor::User(_) = &x.request.author {
+            true
+        } else {
+            false
+        }
+    );
+    
+    let x = user.pop_front();
+    
+
+    if x.is_some() {
+        return x;
+    }
+
+    let x = radio.pop_front();
+    if x.is_some() {
+        return x;
+    }
+ 
+    None
+}
+
+pub async fn play_once_routine(
+    req: TrackRequest,
+    has_played: &mut VecDeque<TrackRecord>)
+{
+    
+    has_played.push_front(
+        TrackRecord {
+            start: Instant::now(),
+            end: Instant::now(),
+            stop_event: EventEnd::UnMarked,
+            req
+        }
+    );
+    
+}
+
+pub async fn play_queue_routine(qctx: Arc<QueueContext>) -> Result<bool, HandlerError> {
+    let mut tries = 4;
+    
+    let handler = qctx.manager.get(qctx.guild_id)
+        .ok_or_else(|| HandlerError::NoCall)?;
+    
+    let mut call = handler.lock().await;
+
+    while let Some((loader, requester)) = next_track(&mut qctx.handle ).await {
+        match loader.load().await {
+            Ok((input, metadata)) => {
+
+                // before_play();
+
+                let (track, trackhandle) = create_player(input);
+                call.enqueue(track);
+                return Ok(true);
+            },
+            Err(why) => {
+                tries -= 1;
+                qctx.invited_from.send_message(&qctx.http, |m| {
+                    m.content(format!("Error loading track: {}", why))
+                }).await?;
+
+                if 0 >= tries {
+                    return Err(why);
+                }
+            }
+        }
+
+        let (track, trackhandle) = create_player(input);
+        
+        call.enqueue(track);
+
+        // , metadata
+    };
+
+
+    Ok(true)
+}
+
+pub async fn leave_routine (
+    data: Arc<RwLock<TypeMap>>,
+    guild_id: GuildId,
+    manager: Arc<Songbird>
+) -> JoinResult<()>
+{   
+    let handler = manager.get(guild_id).unwrap();
+
+    {
+        let mut call = handler.lock().await;
+        call.remove_all_global_events();
+        call.stop();
+    }    
+    
+    manager.remove(guild_id).await?;
+
+    {
+        let mut glob = data.write().await; 
+        let queue = glob.get_mut::<crate::LazyQueueKey>()
+            .expect("Expected LazyQueueKey in TypeMap");
+        queue.remove(&guild_id);
+    }
+
+    Ok(())
+}
+
+pub async fn radio_routine(queue: &mut VecDeque<MetadataType>) 
+-> (Option<PreloadInput>, Vec<HandlerError>) {
+    let mut errors = Vec::new();
+    while let Some(meta) = queue.pop_front() {
+        let mut tries = 5;   
+
+        if let None = meta.source_url() {
+            continue
+        }
+
+        match crate::deemix::deemix_preload(&meta.source_url().unwrap()).await {
+            Ok(preload_input) => return ( Some(preload_input), errors),
+            Err(why) =>  {
+                tries -= 1;
+
+                if 0 >= tries {
+                    break;
+                }
+                tracing::error!("Error preloading radio track: {}", why);
+                errors.push(HandlerError::DeemixError(why));
+            }
+        }
+    }
+    (None, errors)
+}
+
+
+use crate::deemix::SpotifyRecommendError;
+pub async fn after_enqueue(
+    qctx: Arc<QueueContext>,
+) -> Result<(), SpotifyRecommendError> {   
+    
+    let mut queue = qctx.queue; 
+    let pipesize = max_pipe_size().await.expect("Failed to get pipe size");
+    
+    if let Some(radio) = queue.radio {
+        let urls = radio.seeds
+            .iter()
+            .filter_map(|x| match x {
+                MetadataType::Deemix(meta) => Some(meta.isrc.unwrap()),
+                _ => None
+            })
+            .join(" ");
+    
+        let generated = crate::deemix::recommend(urls, 5).await.unwrap();
+        if generated.is_empty() { return Err(SpotifyRecommendError::BadSeeds) }
+
+        let generated = cold_queue.radio_queue.pop_front();
+        generated.unwrap()
+    }
+
+    Ok(())
+}
+
+async fn load_userqueue() -> Result<(), HandlerError> {
+    
+    
+    todo!()
+}
+
+
+async fn join_routine(ctx: &Context, msg: &Message) -> Result<Arc<QueueContext>, JoinError> {
+    let guild = msg.guild(&ctx.cache).unwrap();
+    let guild_id = guild.id;
+
+    let channel_id = guild
+        .voice_states
+        .get(&msg.author.id)
+        .and_then(|voice_state| voice_state.channel_id);
+
+    let connect_to = match channel_id {
+        Some(channel) => channel,
+        None => {
+            msg.reply(&ctx.http, "Not in a voice channel").await.unwrap();
+            return Err(JoinError::NoCall);
+        },
+    };
+
+    let chan: Channel = connect_to.to_channel(&ctx.http).await.unwrap();
+
+    let gchan = match chan {
+        Channel::Guild(ref gchan) => gchan,
+        _ => {
+            msg.reply(
+              &ctx.http,
+              "Not supported voice channel"
+            ).await
+             .unwrap();
+
+            return Err(JoinError::NoCall);
+        }
+    };
+
+    match gchan.bitrate {
+       Some(x) if x > 90_000 => {}
+       None => {
+           let _ = msg.reply(
+               &ctx.http,
+               r#"**Couldn't detect bitrate.** For the best experience,
+check that the voice room is using 128kbps."#).await;
+       }
+       Some(x) => {
+
+            #[cfg(feature = "deemix")]
+            let _ = msg.reply(
+                &ctx,
+                format!(
+                    r#"**Low quality voice channel** detected.
+For the best experience, use 128kbps, & spotify links
+[Currently: {}kbps]"#,  (x / 1000))
+            ).await;
+        }
+    }
+    
+    let manager = songbird::get(ctx)
+        .await
+        .expect("Songbird Voice client placed in at initialisation.")
+        .clone();
+
+    let (_handle_lock, success) = manager.join(guild_id, connect_to).await;
+
+    if let Err(e) = success {
+        return Err(e);
+    }
+    
+    let call_lock = manager.get(guild_id).unwrap(); 
+    let mut call = call_lock.lock().await;
+
+    let queuectx =
+        if let Channel::Guild(voice_chan_id) = chan {
+            QueueContext {
+                guild_id,
+                voice_chan_id,
+                invited_from: msg.channel_id,
+                cache: ctx.cache.clone(),
+                // data: ctx.data.clone(),
+                manager: manager.clone(),
+                http: ctx.http.clone(),
+                queue: Arc::new(RwLock::new(crate::player::Queue {
+                    cold: VecDeque::new(),
+                    warm: VecDeque::new(),
+                    radio: None,
+                    has_played: VecDeque::new(),
+                    killed: Vec::new(),
+                })),
+                // sfx: Arc::new(RwLock::new(todo!())),
+
+            }
+        } else {
+            tracing::error!("Expected voice channel (GuildChannel), got {:?}", chan);
+            return Err(JoinError::NoCall);
+        };
+
+    
+    let queuectx = Arc::new(queuectx);
+    
+    {
+        let mut glob = ctx.data.write().await; 
+        let queue = glob.get_mut::<crate::LazyQueueKey>()
+            .expect("Expected LazyQueueKey in TypeMap");
+        queue.insert(guild_id, queuectx.clone());
+    }
+
+    let _ = call.deafen(true).await;
+    
+    call.add_global_event(
+        Event::Track(TrackEvent::End),
+        crate::player::TrackEndLoader(queuectx.clone())
+    );
+    
+    call.add_global_event(
+        Event::Periodic(crate::TS_ABANDONED_HB, None),
+        crate::player::AbandonedChannel(queuectx.clone())
+    );
+
+    Ok(queuectx)
+}


### PR DESCRIPTION
### Objectives
Just a general clean up to avoid reading long complicated routines.
- [x] rewrite deemix interface to be more programmic
- [x] carry metadata internally in the queue (in ColdQueue[radio-station] or Queue[queue-restructure]) to support 
       - #131 
       - #129 
- [ ] restructure the queuing mechanism to allow N queue & fetch strategies